### PR TITLE
Sometimes ORCIDs end with an X for some reason?

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,5 +1,5 @@
 // should this be configuration?
-var orcidRe = /(\d{4}-\d{4}-\d{4}-\d{4})@orcid\.org/;
+var orcidRe = /(\d{4}-\d{4}-\d{4}-\d{3}[\dX])@orcid\.org/;
 var Url = require('url');
 
 module.exports = {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -3,11 +3,15 @@ var assert = require('assert');
 
 describe('helpers', function () {
   it('emailFromORCID creates an email address', function () {
-    assert.equal(helpers.emailFromORCID('test'), 'test@orcid.org');
+    assert.equal(helpers.emailFromORCID('0000-0003-4959-3049'), '0000-0003-4959-3049@orcid.org');
   });
 
-  it('ORCIDFromEmail strips email leaving username', function () {
-    assert.equal(helpers.ORCIDFromEmail('test@orcid.org', 'test'));
+  it('ORCIDFromEmail strips email leaving ORCID', function () {
+    assert.equal(helpers.ORCIDFromEmail('0000-0003-4959-3049@orcid.org'), '0000-0003-4959-3049');
+  });
+
+  it('ORCIDFromEmail strips email leaving ORCID when ORCID ends in X', function () {
+    assert.equal(helpers.ORCIDFromEmail('0000-0002-3881-294X@orcid.org'), '0000-0002-3881-294X');
   });
 
   it('modEntry removes email and adds ORCID ID', function () {


### PR DESCRIPTION
Updated the regex to catch X ending ORCIDs.

@rcpeters or @wjrsimpson could you review? Is there some sort of documentation for ORCID id naming standards?