### PR TITLE
update view engine & lint

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -8,9 +8,9 @@ module.exports = function () {
     app = express(),
     path = require('path'),
     system = env.get('BADGES_SYSTEM'),
-    Client = require('badgekit-api-client'),
-    jade = require('jade');
+    Client = require('badgekit-api-client');
 
+  app.set('view engine', 'jade');
   app.use(express.static(path.join(__dirname, '..', '/public')));
 
   // Set the client credentials and the OAuth2 server

--- a/test/api.js
+++ b/test/api.js
@@ -3,7 +3,7 @@ var request = require('supertest');
 // provide a session secret for testing
 var config = {
   SESSION_SECRET: 'test_secret'
-}
+};
 
 var app = require('../src/app.js')(config);
 


### PR DESCRIPTION
app.set('view engine', 'jade');

apparently we don't need to requre('jade') before to do this