### PR TITLE
changes for eslint camelCase rule

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -11,7 +11,6 @@
 #  Modified rules:
 #   - arrowFunctions: false // instead of true
 #   - quotes: [2, "single"] // instead of "backtick"
-#   - camelcase: [2, properties: "never"] // instead of "always"
 #   - no-use-before-define: [2, "nofunc"] // instead of defaulting to none
 #
 # The specific environment(s) needed are configured in this file directly.
@@ -60,7 +59,7 @@ rules: # http://eslint.org/docs/rules
 
   block-spacing: [2, "always"]
   brace-style: [2, "1tbs", allowSingleLine: true]
-  camelcase: [2, properties: "never"]
+  camelcase: [2, properties: "always"]
   comma-style: [2, "last"]
   consistent-this: [2, "self"]
   eol-last: [2]

--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,8 @@
 'use strict';
 
+// Custom rule due to the ORCID API using properties not in camelCase
+/* eslint camelcase: [2, {properties: "never"}] */
+
 var bodyParser = require('body-parser');
 var express = require('express');
 var path = require('path');


### PR DESCRIPTION
Chipping away at the mofo-style transition.
The ORCID API uses properties such as _redirect_uri_ so this change adds a custom rule for _camelCase_ in the app.js file only (in which the ORCID API is used) so that the overall rule can be set back to its original value in mofo-style.