### PR TITLE
separates unit and integration tests; npm test still runs them all

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,9 +42,11 @@ easier and smoother.
 
 ## Testing
 
-Any patch should be tested in as many of our supported browsers as possible. Obviously, access to all devices is rare, so just aim for the best coverage possible. At a minimum please test in all available desktop browsers.
+Any patch should be manually tested in as many of our supported browsers as possible. Obviously, access to all devices is rare, so just aim for the best coverage possible. At a minimum please test in all available desktop browsers.
 
-Run tests with `mocha` or `npm test`.
+You can run all automated tests with `mocha test/*` or `npm test`. If _mocha_ is not installed globally, please use `./node_modules/mocha/bin/mocha test/*`.
+
+_Unit_ and _Integration_ tests can also be run separately with `npm run test:unit` and `npm run test:integration` respectively.
 
 ## Pull requests
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "lint": "npm run eslint && npm run eslint:test",
     "build:production": "npm run build:js -- --optimize-minimize --optimize-dedupe",
     "start:production": "npm-run-all build:production server",
-    "test": "mocha"
+    "test:integration": "mocha test/integration",
+    "test:unit": "mocha test/unit",
+    "test": "mocha test/*"
   },
   "dependencies": {
     "babel-loader": "^5.0.0",

--- a/test/integration/app.js
+++ b/test/integration/app.js
@@ -3,15 +3,15 @@
 var request = require('supertest');
 var assert = require('assert');
 
-var testEnv = require('../src/environments');
+var testEnv = require('../../src/environments');
 
-var badgeClient = require('../src/badges/client')(testEnv);
-var badgeService = require('../src/badges/service');
+var badgeClient = require('../../src/badges/client')(testEnv);
+var badgeService = require('../../src/badges/service');
 badgeService.init(badgeClient, testEnv);
 
-var app = require('../src/app.js');
+var app = require('../../src/app.js');
 
-describe('Intergration test against the real Badge server', function () {
+describe('Integration test against the real Badge server', function () {
   before(function () {
     assert.ok(testEnv.get('BADGES_ENDPOINT'), 'should set up BADGES_ENDPOINT in your test environment');
     assert.ok(testEnv.get('BADGES_KEY'), 'should set up BADGES_KEY in your test environment');

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,0 @@
-'use strict';
-
-describe('example test', function() {});

--- a/test/unit/helpers.js
+++ b/test/unit/helpers.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var helpers = require('../src/helpers.js');
+var helpers = require('../../src/helpers.js');
 var assert = require('assert');
 
 describe('helpers', function () {


### PR DESCRIPTION
Because the integration tests run against a real server on the Internet, it would be great to be able to run unit tests (that talk to nothing; no network, no db (or mocked db)) on their own, because they are super fast and they can be run very often (they could be hooked into the commit flow at some point).

`npm test` still runs all tests. Instead of calling on the other two tasks, I prefer to run all of them in the same process, so that the _runner_ reports on all tests (instead of having two report outputs, and having to scroll up on terminal).