### PR TITLE
Fix incorrect api paths in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,13 +109,13 @@ To run the application successfully you need to have [mongodb](https://www.mongo
 *   GET /papers/:doi1/:doi2/badges/:badge
     *   Get all badge instances of a certain badge for a paper.
     *   e.g. [/papers/10.1186/2047-217X-3-18/badges/investigation](http://badges.mozillascience.org/papers/10.1186/2047-217X-3-18/badges/investigation)
-*   GET /papers/:doi1/:doi2/badges/:orcid/badges
+*   GET /papers/:doi1/:doi2/users/:orcid/badges
     *   Get all badge instances earned by a user for a paper.
     *   e.g. [/papers/10.1186/2047-217X-3-18/users/0000-0001-5979-8713/badges](http://badges.mozillascience.org/papers/10.1186/2047-217X-3-18/users/0000-0001-5979-8713/badges)
-*   GET /papers/:doi1/:doi2/badges/:orcid/badges/:badge
+*   GET /papers/:doi1/:doi2/users/:orcid/badges/:badge
     *   Get all badge instances of a certain badge earned by a user for a paper.
     *   e.g. [/papers/10.1186/2047-217X-3-18/users/0000-0001-5979-8713/badges/data_curation](http://badges.mozillascience.org/papers/10.1186/2047-217X-3-18/users/0000-0001-5979-8713/badges/data_curation)
-*   POST /papers/:doi1/:doi2/badges/:orcid/badges/:badge
+*   POST /papers/:doi1/:doi2/users/:orcid/badges/:badge
     *   Issue a badge
 
 ***

--- a/templates/pages/home.jsx
+++ b/templates/pages/home.jsx
@@ -70,19 +70,19 @@ var Home = React.createClass({
               <li>e.g. <a href="/papers/10.1186/2047-217X-3-18/badges/investigation?pretty=true">/papers/10.1186/2047-217X-3-18/badges/investigation</a></li>
             </ul>
           </li>
-          <li>GET /papers/:doi1/:doi2/badges/:orcid/badges
+          <li>GET /papers/:doi1/:doi2/users/:orcid/badges
             <ul>
               <li>Get all badge instances earned by a user for a paper.</li>
               <li>e.g. <a href="/papers/10.1186/2047-217X-3-18/users/0000-0001-5979-8713/badges?pretty=true">/papers/10.1186/2047-217X-3-18/users/0000-0001-5979-8713/badges</a></li>
             </ul>
           </li>
-          <li>GET /papers/:doi1/:doi2/badges/:orcid/badges/:badge
+          <li>GET /papers/:doi1/:doi2/users/:orcid/badges/:badge
             <ul>
               <li>Get all badge instances of a certain badge earned by a user for a paper.</li>
               <li>e.g. <a href="/papers/10.1186/2047-217X-3-18/users/0000-0001-5979-8713/badges/data_curation?pretty=true">/papers/10.1186/2047-217X-3-18/users/0000-0001-5979-8713/badges/data_curation</a></li>
             </ul>
           </li>
-          <li>POST /papers/:doi1/:doi2/badges/:orcid/badges/:badge
+          <li>POST /papers/:doi1/:doi2/users/:orcid/badges/:badge
             <ul>
               <li>Issue a badge</li>
             </ul>


### PR DESCRIPTION
There are some typos in the README. `users` were typed into `badges`. I found them when writing a GSoC proposal for your project.@acabunoc 

Actually this kind of api doc is not convenient to maintain, I suggest using Swagger to drive the API documentation. I will further clarify that in my porposal.