### PR TITLE
disabling integration tests for Travis from pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: node_js
 sudo: false
 node_js:
   - "0.12"
+script: ./scripts/run-tests.sh

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -ev
+if [ "${TRAVIS_PULL_REQUEST}" = "false" ]
+then
+  npm test
+else
+  npm run test:unit
+fi


### PR DESCRIPTION
This is a test to avoid the issue of builds crashing when started from pull requests (due to encrypted variables in the main repo that cannot be shared with forks)