### PR TITLE
Update docker image to use node.js version 6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
 
   paperbadger:
-    image: node:0.12
+    image: node:6
     command: bash -c 'cd /src && (if [ ! -d "node_modules" ]; then npm install && chmod -R uo+w node_modules; fi) && npm start'
     ports:
       - 5000:5000

--- a/package.json
+++ b/package.json
@@ -51,9 +51,6 @@
     "nock": "^2.3.0",
     "supertest": "^1.0.1"
   },
-  "engines": {
-    "node": "0.12.2"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/mozillascience/PaperBadger"


### PR DESCRIPTION
I tried running the webapp on the latest node (using the `node:6` docker image) and it seems to work just fine. Also I managed to run the tests and only one fails, for unrelated reasons I guess

```
❯ docker exec -it paperbadger_paperbadger_1 bash -c 'cd /src && npm test'
npm info it worked if it ends with ok
npm info using npm@3.8.9
npm info using node@v6.2.0
npm info lifecycle PaperBadger@0.1.1~pretest: PaperBadger@0.1.1
npm info lifecycle PaperBadger@0.1.1~test: PaperBadger@0.1.1

> PaperBadger@0.1.1 test /src
> mocha test/*



  Integration test against the real Badge server
connection!
    ✓ get all the badges (834ms)
    1) render JSON data in pug with the pretty param
    ✓ get a count of all the badges (751ms)
    ✓ get all badge instances of a certain badge (1060ms)
    ✓ get a count of all badge instances of a certain badge (1055ms)
    ✓ get all badge instances earned by a user (625ms)
    ✓ get a count of all badge instances earned by a user (606ms)
    ✓ get all badge instances of a certain badge earned by a user (608ms)
    ✓ get a count of all badge instances of a certain badge earned by a user (611ms)
    ✓ get all badges of a certain paper (1798ms)
    ✓ get the number of badges of a certain paper (1798ms)
    ✓ get all badge instances of a certain badge for a paper (630ms)
    ✓ get the badge count for instances of a certain badge for a paper (617ms)
    ✓ get all badge instances earned by a user for a paper. (732ms)
    ✓ get a count of all badge instances earned by a user for a paper. (649ms)
    ✓ get all badge instances of a certain badge earned by a user for a paper. (673ms)
    ✓ get a count of all badge instances of a certain badge earned by a user for a paper. (631ms)

  helpers
    ✓ emailFromORCID creates an email address
    ✓ ORCIDFromEmail strips email leaving ORCID
    ✓ ORCIDFromEmail strips email leaving ORCID when ORCID ends in X
    ✓ modEntry removes email and adds ORCID ID
    ✓ modEntry deletes only email from entry
    ✓ urlFromDOI returns a doi.org URI given a DOI
    ✓ DOIFromURL returns a DOI given a URI


  23 passing (17s)
  1 failing

  1) Integration test against the real Badge server render JSON data in pug with the pretty param:
     Error: timeout of 2000ms exceeded. Ensure the done() callback is being called in this test.




npm info lifecycle PaperBadger@0.1.1~test: Failed to exec test script
npm ERR! Test failed.  See above for more details.
```

not entirely sure about the failing test

If I do `curl -v 'http://localhost:5000/badges?pretty=true'` I get what the test expects (without any delay).

```
* Connected to localhost (127.0.0.1) port 5000 (#0)
> GET /badges?pretty=true HTTP/1.1
> Host: localhost:5000
> User-Agent: curl/7.43.0
> Accept: */*
>
< HTTP/1.1 200 OK
< X-Powered-By: Express
< Access-Control-Allow-Origin: *
< Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept
< Content-Type: text/html; charset=utf-8
< Content-Length: 22118
< ETag: W/"PXLxDwZqawDhgorXG09CKg=="
< set-cookie: sid=s%3AD-H7m5D924GyUPef06M6syJeNnmLKcSy.QL20t5xvHlZwTtdez4OK8oibhTtzrdERQeCe2vbobrM; Path=/; HttpOnly
< Date: Fri, 03 Jun 2016 02:40:52 GMT
< Connection: keep-alive
<
```

maybe I am running the tests again something else than my running copy :thinking_face:

Anyway, I'll open this PR as it's a starting point.
