### PR TITLE
Allow BADGES_SECRET env variables to be overridden with docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     volumes:
       - .:/src
     environment:
+      - BADGES_SECRET
       - MONGOLAB_URI=mongodb://mongo:27017/test
       - REDISCLOUD_URL=redis://redis:6379/0
 


### PR DESCRIPTION
docker-compose does not read environment variables unless they are specified in the `docker-compose.yml`, which is annoying if trying to override env vars like `BADGES_SECRET` without changing the `default.env` file

I'm not really an expert on docker, and I couldn't find a good reference on this (apart from [this](https://docs.docker.com/compose/link-env-deprecated/) which is a little vague), so if there's a better way that I'm missing please let me know 😄